### PR TITLE
[CI] Fix build error because of passenger-docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN wget -qO- $ORTOOLS_URL | tar xz --strip-components=1 -C /srv/or-tools
 ADD . /srv/optimizer-ortools
 
 WORKDIR /srv/optimizer-ortools
-RUN make tsp_simple
+RUN make -j3 tsp_simple


### PR DESCRIPTION
LetsEncrypt expired the DST Root CA X3 certificates so apt-get cannot
validate the certificate of passenger-docker because phusion fixed the
issue only on Ruby 2.6+ images because Ruby 2.5 is end-of-life.