### PR TITLE
[optim-api] Fix: respect compatible vehicle list

### DIFF
--- a/tsptw_data_dt.h
+++ b/tsptw_data_dt.h
@@ -249,10 +249,6 @@ public:
     return tsptw_clients_[i.value()].vehicle_indices;
   }
 
-  void SetVehicleIndices(const int64 i, std::vector<int64>&& vehicle_indices) {
-    tsptw_clients_[i].vehicle_indices = std::move(vehicle_indices);
-  }
-
   int32 TimeWindowsSize(const int i) const { return tws_size_[i]; }
 
   int32 Size() const { return size_; }


### PR DESCRIPTION
Vehicle indices list is not respected if the service is infeasible -- i.e., empty vehicle indices list.

- [ ] Needs https://github.com/Mapotempo/optimizer-api/pull/318